### PR TITLE
Fix version spec.

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -3,5 +3,5 @@
 (define deps '(("ddict" "0.1")))
 (define collection 'multi)
 (define categories '(ffi automatisation code-generation))
-(define version "0.2.0")
+(define version "0.2")
 (define compile-omit-paths '("example"))


### PR DESCRIPTION
Trailing .0 is not allowed.